### PR TITLE
Add parameters

### DIFF
--- a/examples/test.tf
+++ b/examples/test.tf
@@ -4,9 +4,16 @@ provider "healthchecksio" {
 
 resource "healthchecksio_check" "test" {
   name = "test-check"
+
   tags = [
     "go",
     "gophers",
     "unite",
   ]
+
+  grace = 120
+
+  # timeout = 300
+  schedule = "0,30 2 * * *"
+  timezone = "Asia/Tokyo"
 }

--- a/healthchecksio/resource_check.go
+++ b/healthchecksio/resource_check.go
@@ -28,6 +28,11 @@ func resourceHealthcheck() *schema.Resource {
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"grace": &schema.Schema{
+				Type:        schema.TypeInt,
+				Description: "Grace period for the healthcheck",
+				Optional:    true,
+			},
 			"schedule": &schema.Schema{
 				Type:        schema.TypeString,
 				Description: "Schedule defining the healthcheck",
@@ -91,6 +96,7 @@ func resourceHealthcheckRead(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("name", healthcheck.Name)
 	d.Set("tags", strings.Split(healthcheck.Tags, " "))
+	d.Set("grace", healthcheck.Grace)
 	d.Set("schedule", healthcheck.Schedule)
 	d.Set("timezone", healthcheck.Timezone)
 
@@ -110,7 +116,7 @@ func resourceHealthcheckUpdate(d *schema.ResourceData, m interface{}) error {
 
 	log.Printf("[DEBUG] healthcheck update: %#v", healthcheck)
 
-	if d.HasChange("tags") || d.HasChange("schedule") || d.HasChange("timezone") {
+	if d.HasChange("tags") || d.HasChange("grace") || d.HasChange("schedule") || d.HasChange("timezone") {
 		_, err = client.Update(key, *healthcheck)
 		if err != nil {
 			return fmt.Errorf("Failed to update healthcheck: %s", err)
@@ -143,6 +149,10 @@ func createHealthcheckFromResourceData(d *schema.ResourceData) (*healthchecksio.
 	if attr, ok := d.GetOk("tags"); ok {
 		tags := toSliceOfString(attr.([]interface{}))
 		healthcheck.Tags = strings.Join(tags, " ")
+	}
+
+	if attr, ok := d.GetOk("grace"); ok {
+		healthcheck.Grace = attr.(int)
 	}
 
 	if attr, ok := d.GetOk("schedule"); ok {

--- a/healthchecksio/resource_check.go
+++ b/healthchecksio/resource_check.go
@@ -122,7 +122,7 @@ func resourceHealthcheckUpdate(d *schema.ResourceData, m interface{}) error {
 
 	log.Printf("[DEBUG] healthcheck update: %#v", healthcheck)
 
-	if d.HasChange("tags") || d.HasChange("timeout") || d.HasChange("grace") || d.HasChange("schedule") || d.HasChange("timezone") {
+	if hasChange(d) {
 		_, err = client.Update(key, *healthcheck)
 		if err != nil {
 			return fmt.Errorf("Failed to update healthcheck: %s", err)
@@ -185,4 +185,10 @@ func toSliceOfString(a []interface{}) []string {
 		}
 	}
 	return vs
+}
+
+func hasChange(d *schema.ResourceData) bool {
+	return d.HasChange("tags") || d.HasChange("timeout") ||
+		d.HasChange("grace") || d.HasChange("schedule") ||
+		d.HasChange("timezone")
 }

--- a/healthchecksio/resource_check.go
+++ b/healthchecksio/resource_check.go
@@ -28,6 +28,11 @@ func resourceHealthcheck() *schema.Resource {
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"schedule": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Schedule defining the healthcheck",
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -81,6 +86,7 @@ func resourceHealthcheckRead(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("name", healthcheck.Name)
 	d.Set("tags", strings.Split(healthcheck.Tags, " "))
+	d.Set("schedule", healthcheck.Schedule)
 
 	return nil
 }
@@ -98,7 +104,7 @@ func resourceHealthcheckUpdate(d *schema.ResourceData, m interface{}) error {
 
 	log.Printf("[DEBUG] healthcheck update: %#v", healthcheck)
 
-	if d.HasChange("tags") {
+	if d.HasChange("tags") || d.HasChange("schedule") {
 		_, err = client.Update(key, *healthcheck)
 		if err != nil {
 			return fmt.Errorf("Failed to update healthcheck: %s", err)
@@ -131,6 +137,10 @@ func createHealthcheckFromResourceData(d *schema.ResourceData) (*healthchecksio.
 	if attr, ok := d.GetOk("tags"); ok {
 		tags := toSliceOfString(attr.([]interface{}))
 		healthcheck.Tags = strings.Join(tags, " ")
+	}
+
+	if attr, ok := d.GetOk("schedule"); ok {
+		healthcheck.Schedule = attr.(string)
 	}
 
 	return &healthcheck, nil

--- a/healthchecksio/resource_check.go
+++ b/healthchecksio/resource_check.go
@@ -33,6 +33,11 @@ func resourceHealthcheck() *schema.Resource {
 				Description: "Schedule defining the healthcheck",
 				Optional:    true,
 			},
+			"timezone": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Timezone used for the schedule",
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -87,6 +92,7 @@ func resourceHealthcheckRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("name", healthcheck.Name)
 	d.Set("tags", strings.Split(healthcheck.Tags, " "))
 	d.Set("schedule", healthcheck.Schedule)
+	d.Set("timezone", healthcheck.Timezone)
 
 	return nil
 }
@@ -104,7 +110,7 @@ func resourceHealthcheckUpdate(d *schema.ResourceData, m interface{}) error {
 
 	log.Printf("[DEBUG] healthcheck update: %#v", healthcheck)
 
-	if d.HasChange("tags") || d.HasChange("schedule") {
+	if d.HasChange("tags") || d.HasChange("schedule") || d.HasChange("timezone") {
 		_, err = client.Update(key, *healthcheck)
 		if err != nil {
 			return fmt.Errorf("Failed to update healthcheck: %s", err)
@@ -141,6 +147,10 @@ func createHealthcheckFromResourceData(d *schema.ResourceData) (*healthchecksio.
 
 	if attr, ok := d.GetOk("schedule"); ok {
 		healthcheck.Schedule = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("timezone"); ok {
+		healthcheck.Timezone = attr.(string)
 	}
 
 	return &healthcheck, nil

--- a/healthchecksio/resource_check.go
+++ b/healthchecksio/resource_check.go
@@ -28,6 +28,11 @@ func resourceHealthcheck() *schema.Resource {
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"timeout": &schema.Schema{
+				Type:        schema.TypeInt,
+				Description: "Timeout expected period of the healthcheck",
+				Optional:    true,
+			},
 			"grace": &schema.Schema{
 				Type:        schema.TypeInt,
 				Description: "Grace period for the healthcheck",
@@ -96,6 +101,7 @@ func resourceHealthcheckRead(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("name", healthcheck.Name)
 	d.Set("tags", strings.Split(healthcheck.Tags, " "))
+	d.Set("timeout", healthcheck.Timeout)
 	d.Set("grace", healthcheck.Grace)
 	d.Set("schedule", healthcheck.Schedule)
 	d.Set("timezone", healthcheck.Timezone)
@@ -116,7 +122,7 @@ func resourceHealthcheckUpdate(d *schema.ResourceData, m interface{}) error {
 
 	log.Printf("[DEBUG] healthcheck update: %#v", healthcheck)
 
-	if d.HasChange("tags") || d.HasChange("grace") || d.HasChange("schedule") || d.HasChange("timezone") {
+	if d.HasChange("tags") || d.HasChange("timeout") || d.HasChange("grace") || d.HasChange("schedule") || d.HasChange("timezone") {
 		_, err = client.Update(key, *healthcheck)
 		if err != nil {
 			return fmt.Errorf("Failed to update healthcheck: %s", err)
@@ -149,6 +155,10 @@ func createHealthcheckFromResourceData(d *schema.ResourceData) (*healthchecksio.
 	if attr, ok := d.GetOk("tags"); ok {
 		tags := toSliceOfString(attr.([]interface{}))
 		healthcheck.Tags = strings.Join(tags, " ")
+	}
+
+	if attr, ok := d.GetOk("timeout"); ok {
+		healthcheck.Timeout = attr.(int)
 	}
 
 	if attr, ok := d.GetOk("grace"); ok {


### PR DESCRIPTION
Hi @kristofferahl,

I added the following parameters.

* schedule
* timezone
* grace
* timeout

I wanted to add `channels` parameter too. But healthchecks.io does not contain it in the response. I have found an issue https://github.com/healthchecks/healthchecks/issues/157 that seems to be related.

---

I want this binary is release to https://github.com/kristofferahl/terraform-provider-healthchecksio/releases .

In addition, if this provider plugin is installed by `$ terraform init`, I feel so happy. :smile: Is it difficult?

