### PR TITLE
Feature: Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ jobs:
     steps:
       - checkout
       - run: ./run docker build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist
   test:
     machine:
       docker_layer_caching: true
@@ -17,6 +21,8 @@ jobs:
       docker_layer_caching: true
     steps:
       - checkout
+      - attach_workspace:
+          at: ./
       - run: ./run docker test-integration
   release:
     machine:
@@ -41,12 +47,6 @@ workflows:
           requires:
             - test
             - integration-test
-          filters:
-            branches:
-              only: master
       - release:
           requires:
             - approve-release
-          filters:
-            branches:
-              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       docker_layer_caching: true
     steps:
       - checkout
-      - run: echo "Releaseing..."
+      - run: ./run docker release
 
 workflows:
   version: 2
@@ -47,6 +47,12 @@ workflows:
           requires:
             - test
             - integration-test
+          filters:
+            branches:
+              only: master
       - release:
           requires:
             - approve-release
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2
+jobs:
+  build:
+    machine:
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run: ./run docker test
+      - run: ./run docker build
+      - run: ./run docker test-integration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,48 @@ jobs:
       docker_layer_caching: true
     steps:
       - checkout
-      - run: ./run docker test
       - run: ./run docker build
+  test:
+    machine:
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run: ./run docker test
+  integration-test:
+    machine:
+      docker_layer_caching: true
+    steps:
+      - checkout
       - run: ./run docker test-integration
+  release:
+    machine:
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run: echo "Releaseing..."
+
+workflows:
+  version: 2
+  build-test-release:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build
+      - integration-test:
+          requires:
+            - build
+      - approve-release:
+          type: approval
+          requires:
+            - test
+            - integration-test
+          filters:
+            branches:
+              only: master
+      - release:
+          requires:
+            - approve-release
+          filters:
+            branches:
+              only: master

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Terraform Provider for healthchecks.io
 
+[![CircleCI](https://circleci.com/gh/kristofferahl/terraform-provider-healthchecksio/tree/master.svg?style=svg)](https://circleci.com/gh/kristofferahl/terraform-provider-healthchecksio/tree/master)
+
 ## Usage
 
 ### Provider configuration

--- a/run
+++ b/run
@@ -53,10 +53,6 @@ run_build() {
 }
 
 run_release() {
-  run_build
-  run_test
-  run_test_integration
-
   log INF 'Creating a release using goreleaser...'
   goreleaser --rm-dist
 }

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -2,8 +2,8 @@ FROM golang:1.12.6-stretch
 ARG TERRAFORM_VERSION
 LABEL maintainer="Dotnet Mentor <info@dotnetmentor.se>"
 RUN apt-get update && apt-get install -y git bash openssl curl unzip
-RUN curl -L https://github.com/goreleaser/goreleaser/releases/download/v0.110.0/goreleaser_Linux_arm64.tar.gz > goreleaser_Linux_arm64.tar.gz
-RUN tar -xzf goreleaser_Linux_arm64.tar.gz && mv goreleaser /bin/goreleaser && chmod +x /bin/goreleaser && rm goreleaser_Linux_arm64.tar.gz
+RUN curl -L https://github.com/goreleaser/goreleaser/releases/download/v0.110.0/goreleaser_Linux_x86_64.tar.gz > goreleaser_Linux_x86_64.tar.gz
+RUN tar -xzf goreleaser_Linux_x86_64.tar.gz && mv goreleaser /bin/goreleaser && chmod +x /bin/goreleaser && rm goreleaser_Linux_x86_64.tar.gz && goreleaser --version
 RUN curl -L https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip > terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 RUN unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && mv terraform /bin/terraform && chmod +x /bin/terraform && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip && terraform --version
 WORKDIR /work/


### PR DESCRIPTION
**Work in progress**

Closes #9 

Setup a CI workflow with multiple jobs for
- building (dist)
- running test
- running integration tests
- approve release (only on master branch) 
- release (with goreleaser, only on master branch)

<img width="973" alt="circleci-workflow" src="https://user-images.githubusercontent.com/288937/60547761-cae48900-9d20-11e9-8d82-c2d0dcb8b1f2.png">

Obviously haven't tried the release job as it requires merging to master but I did try the approval process by removing the branch filter.

Build status should be public but approval requires access to Circle CI. Will grant access once this is approved and merged.

What do you think? Are we missing something? @masutaka @rossmckelvie  