### PR TITLE
Bump golang to 1.13

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,6 @@ builds:
   binary: "{{ .ProjectName }}_{{ .Tag }}"
   env:
   - CGO_ENABLED=0
-  - GO111MODULE=on
 archives:
 - replacements:
     darwin: Darwin

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ terraform import healthchecksio_check.my_first_check 760ca858-576a-432b-8b1f-3
 ## Development
 
 ### Pre-requisites
-- [Go](https://golang.org/) 1.12 or later
+- [Go](https://golang.org/) 1.13 or later
 - [Terraform](https://www.terraform.io/) v0.12 or later
 - [Healthchecks.io](https://healthchecks.io/) account and an API key
 - [goreleaser](https://goreleaser.com/) 0.110.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kristofferahl/terraform-provider-healthchecksio
 
-go 1.12
+go 1.13
 
 require (
 	github.com/hashicorp/terraform v0.12.2

--- a/run
+++ b/run
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-export GO111MODULE=on
 export TERRAFORM_VERSION='0.12.2'
 
 declare -r plugins_dir=".terraform/plugins"

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -7,7 +7,6 @@ RUN tar -xzf goreleaser_Linux_x86_64.tar.gz && mv goreleaser /bin/goreleaser && 
 RUN curl -L https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip > terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 RUN unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && mv terraform /bin/terraform && chmod +x /bin/terraform && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip && terraform --version
 WORKDIR /work/
-ENV GO111MODULE=on
 COPY go.mod .
 COPY go.sum .
 RUN go mod download

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.12.6-stretch
+FROM golang:1.13.1-stretch
 ARG TERRAFORM_VERSION
 LABEL maintainer="Dotnet Mentor <info@dotnetmentor.se>"
 RUN apt-get update && apt-get install -y git bash openssl curl unzip


### PR DESCRIPTION
https://tip.golang.org/doc/go1.13

If this PR is merged, I'll create PR to switch to [terraform-plugin-sdk](https://github.com/hashicorp/terraform-plugin-sdk). See also https://www.terraform.io/docs/extend/plugin-sdk.html