### PR TITLE
Add ping_url and pause_url props to healthchecksio_check resource

### DIFF
--- a/healthchecksio/resource_check.go
+++ b/healthchecksio/resource_check.go
@@ -60,6 +60,16 @@ func resourceHealthcheck() *schema.Resource {
 				Description: "Channels integrated with the healthcheck",
 				Optional:    true,
 			},
+			"ping_url": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Ping URL associated with this healthcheck",
+				Computed:    true,
+			},
+			"pause_url": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Pause URL associated with this healthcheck",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -122,6 +132,8 @@ func resourceHealthcheckRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("schedule", healthcheck.Schedule)
 	d.Set("timezone", healthcheck.Timezone)
 	d.Set("channels", healthcheck.Channels)
+	d.Set("ping_url", healthcheck.PingURL)
+	d.Set("pause_url", healthcheck.PauseURL)
 
 	return nil
 }


### PR DESCRIPTION
Seems like these would both be very useful to feed in as inputs to something else (eg. I'm passing these through into a helm deployment of prometheus-operator to configure the deadmansswitch alert with the correct hs-ping url)